### PR TITLE
Fixing typo that breaks unit tests

### DIFF
--- a/templates/home.html
+++ b/templates/home.html
@@ -5,7 +5,7 @@
     <div class="row justify-content-center">
         <div class="col-lg-6">
             <div>
-                <p class="small mb-0">welcome to</p>
+                <p class="small mb-0">Welcome to</p>
                 <h1 class="mb-0" style="font-size: 4rem">Picture This</h1>
                 <p class="lead mb-4">your virtual vision board</p>
             </div>


### PR DESCRIPTION
The unit tests look for the string "Welcome", rather than "welcome".